### PR TITLE
npmjs ではなく GitHub への参照に変更します

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,7 @@
   "requires": true,
   "dependencies": {
     "@umm/setting_core": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@umm/setting_core/-/setting_core-1.0.1.tgz",
-      "integrity": "sha512-6H5DzfIsD9dwfD1iPOsTmNuGwR9+kkDv+Yw3NXtT1Nnk7mdVOz5QqyWZ5IwrCcHLNJi5F1OfR2o0drS7q7OIbg==",
+      "version": "github:umm-projects/setting_core#cfcf8a2f68ed6358f1df4750c365b963ae1ff604",
       "requires": {
         "glob": "7.1.2",
         "mkdirp": "0.5.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "scripts"
   ],
   "dependencies": {
-    "@umm/setting_core": "~1",
+    "@umm/setting_core": "github:umm-projects/setting_core.git",
     "glob": "^7.1.2",
     "mkdirp": "^0.5.1",
     "ncp": "^2.0.0",


### PR DESCRIPTION
* JS じゃないファイルを npmjs で管理するのは NG かと思い、GitHub を参照するように変更しました。